### PR TITLE
✅ Implementation of unit tests

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -434,28 +434,120 @@ pub fn compute_mosaic(args: Options) {
 }
 
 fn main() {
-    let args = Options::parse();
+    let args = Options::parse(); 
     compute_mosaic(args);
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use image::RgbImage;
+    use std::fs;
+
+    /// Helper function that creates two simple 4x4 test images
+    /// and returns them with the expected L1 distance between them.
+    fn create_test_images() -> (RgbImage, RgbImage, i32) {
+        let mut im1 = RgbImage::new(4, 4);
+        let mut im2 = RgbImage::new(4, 4);
+
+        // Fill first image with RGB (10, 20, 30)
+        for pixel in im1.pixels_mut() {
+            *pixel = image::Rgb([10, 20, 30]);
+        }
+
+        // Fill second image with RGB (15, 25, 35)
+        for pixel in im2.pixels_mut() {
+            *pixel = image::Rgb([15, 25, 35]);
+        }
+
+        // Expected distance = sum of absolute differences for each pixel and each channel
+        // Each pixel contributes (5 + 5 + 5) = 15 → 4x4 pixels → 16 * 15 = 240
+        let expected_distance = 4 * 4 * (5 + 5 + 5);
+        (im1, im2, expected_distance)
+    }
+
+    // ---- L1 TESTS ----
+    // These tests verify that L1 distance computation gives the expected result
+    // across different CPU architectures and instruction sets (AVX2, SSE2, NEON).
+
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn unit_test_x86() {
-        // TODO
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        unsafe {
+            if is_x86_feature_detected!("avx2") {
+                // Test optimized AVX2 version
+                assert_eq!(l1_x86_avx2(&im1, &im2), expected);
+            } else if is_x86_feature_detected!("sse2") {
+                // Test SSE2 fallback version
+                assert_eq!(l1_x86_sse2(&im1, &im2), expected);
+            } else {
+                // If no SIMD instruction set is available, skip test
+                assert!(true);
+            }
+        }
     }
 
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn unit_test_aarch64() {
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        unsafe {
+            // Test NEON implementation for ARM CPUs
+            assert_eq!(l1_neon(&im1, &im2), expected);
+        }
     }
 
     #[test]
     fn unit_test_generic() {
-        // TODO
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        // Test generic (non-optimized) version
+        assert_eq!(l1_generic(&im1, &im2), expected);
+    }
+
+    // ---- TILE TEST ----
+    // This test checks that the tile preparation function loads and resizes images correctly.
+
+    #[test]
+    fn test_prepare_tiles_size() {
+        let dir = "test_tiles";
+        fs::create_dir_all(dir).unwrap();
+
+        // Create 3 dummy 8x8 images
+        for i in 0..3 {
+            let img = RgbImage::new(8, 8);
+            img.save(format!("{}/img{}.png", dir, i)).unwrap();
+        }
+
+        let tile_size = Size { width: 4, height: 4 };
+        let tiles = prepare_tiles(dir, &tile_size, false).unwrap();
+
+        // Check that 3 tiles were generated, each resized to 4x4
+        assert_eq!(tiles.len(), 3);
+        for tile in tiles {
+            assert_eq!(tile.width(), 4);
+            assert_eq!(tile.height(), 4);
+        }
+
+        fs::remove_dir_all(dir).unwrap();
+    }
+
+    // ---- TARGET TEST ----
+    // This test checks that the target image is properly resized and prepared.
+
+    #[test]
+    fn test_prepare_target_size() {
+        let img = RgbImage::new(8, 8);
+        let path = "test_input.png";
+        img.save(path).unwrap();
+
+        let tile_size = Size { width: 4, height: 4 };
+        let result = prepare_target(path, 1, &tile_size).unwrap();
+
+        // The target should be correctly resized to 4x4
+        assert_eq!(result.width(), 8);
+        assert_eq!(result.height(), 8);
+
+        fs::remove_file(path).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -444,31 +444,17 @@ mod tests {
     use image::RgbImage;
     use std::fs;
 
-    /// Helper function that creates two simple 4x4 test images
-    /// and returns them with the expected L1 distance between them.
     fn create_test_images() -> (RgbImage, RgbImage, i32) {
         let mut im1 = RgbImage::new(4, 4);
         let mut im2 = RgbImage::new(4, 4);
 
-        // Fill first image with RGB (10, 20, 30)
-        for pixel in im1.pixels_mut() {
-            *pixel = image::Rgb([10, 20, 30]);
-        }
+        im1.pixels_mut().for_each(|p| *p = image::Rgb([10, 20, 30]));
+        im2.pixels_mut().for_each(|p| *p = image::Rgb([15, 25, 35]));
 
-        // Fill second image with RGB (15, 25, 35)
-        for pixel in im2.pixels_mut() {
-            *pixel = image::Rgb([15, 25, 35]);
-        }
-
-        // Expected distance = sum of absolute differences for each pixel and each channel
-        // Each pixel contributes (5 + 5 + 5) = 15 → 4x4 pixels → 16 * 15 = 240
         let expected_distance = 4 * 4 * (5 + 5 + 5);
         (im1, im2, expected_distance)
     }
 
-    // ---- L1 TESTS ----
-    // These tests verify that L1 distance computation gives the expected result
-    // across different CPU architectures and instruction sets (AVX2, SSE2, NEON).
 
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
@@ -476,13 +462,10 @@ mod tests {
         let (im1, im2, expected) = create_test_images();
         unsafe {
             if is_x86_feature_detected!("avx2") {
-                // Test optimized AVX2 version
                 assert_eq!(l1_x86_avx2(&im1, &im2), expected);
             } else if is_x86_feature_detected!("sse2") {
-                // Test SSE2 fallback version
                 assert_eq!(l1_x86_sse2(&im1, &im2), expected);
             } else {
-                // If no SIMD instruction set is available, skip test
                 assert!(true);
             }
         }
@@ -493,7 +476,6 @@ mod tests {
     fn unit_test_aarch64() {
         let (im1, im2, expected) = create_test_images();
         unsafe {
-            // Test NEON implementation for ARM CPUs
             assert_eq!(l1_neon(&im1, &im2), expected);
         }
     }
@@ -501,19 +483,15 @@ mod tests {
     #[test]
     fn unit_test_generic() {
         let (im1, im2, expected) = create_test_images();
-        // Test generic (non-optimized) version
         assert_eq!(l1_generic(&im1, &im2), expected);
     }
 
-    // ---- TILE TEST ----
-    // This test checks that the tile preparation function loads and resizes images correctly.
 
     #[test]
     fn test_prepare_tiles_size() {
         let dir = "test_tiles";
         fs::create_dir_all(dir).unwrap();
 
-        // Create 3 dummy 8x8 images
         for i in 0..3 {
             let img = RgbImage::new(8, 8);
             img.save(format!("{}/img{}.png", dir, i)).unwrap();
@@ -522,7 +500,6 @@ mod tests {
         let tile_size = Size { width: 4, height: 4 };
         let tiles = prepare_tiles(dir, &tile_size, false).unwrap();
 
-        // Check that 3 tiles were generated, each resized to 4x4
         assert_eq!(tiles.len(), 3);
         for tile in tiles {
             assert_eq!(tile.width(), 4);
@@ -532,8 +509,7 @@ mod tests {
         fs::remove_dir_all(dir).unwrap();
     }
 
-    // ---- TARGET TEST ----
-    // This test checks that the target image is properly resized and prepared.
+
 
     #[test]
     fn test_prepare_target_size() {
@@ -544,10 +520,14 @@ mod tests {
         let tile_size = Size { width: 4, height: 4 };
         let result = prepare_target(path, 1, &tile_size).unwrap();
 
-        // The target should be correctly resized to 4x4
         assert_eq!(result.width(), 8);
         assert_eq!(result.height(), 8);
 
         fs::remove_file(path).unwrap();
+        let invalid_path = "non_existing_image.png";
+        let tile_size = Size { width: 4, height: 4 };
+        let result = prepare_target(invalid_path, 1, &tile_size);
+
+    assert!(result.is_err(),"Expected error when trying to open a non-existing image");
     }
 }

--- a/tests/temp.rs
+++ b/tests/temp.rs
@@ -1,23 +1,71 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn test_x86() {
-        // TODO
-        // test avx2 or sse2 if available
-        assert!(false);
-    }
+use moseiik::main::{Options, compute_mosaic};
+use image::{RgbImage, ImageReader};
 
-    #[test]
-    #[cfg(target_arch = "aarch64")]
-    fn test_aarch64() {
-        //TODO
-        assert!(false);
-    }
+fn load_image(path: &str) -> RgbImage {
+    ImageReader::open(path)
+        .expect(&format!("Cannot open image: {}", path))
+        .decode()
+        .expect("Failed to decode image")
+        .into_rgb8()
+}
 
-    #[test]
-    fn test_generic() {
-        //TODO
-        assert!(false);
+fn default_options(output: &str) -> Options {
+    Options {
+        image: "assets/kit.jpeg".into(),          
+        output: output.into(),                    
+        tiles: "assets/moseiik_test_images/images".into(),       
+        scaling: 1,
+        tile_size: 25,                             
+        remove_used: false,
+        verbose: false,
+        simd: false,
+        num_thread: 1,
     }
+}
+
+#[test]
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn test_x86() {
+    let output = "tests/output_x86.png";
+    let options = default_options(output);
+
+    compute_mosaic(options);
+
+    let generated = load_image(output);
+    let ground = load_image("assets/ground-truth-kit.png");
+
+    assert_eq!(generated, ground);
+
+    std::fs::remove_file(output).unwrap();
+}
+
+#[test]
+#[cfg(target_arch = "aarch64")]
+fn test_aarch64() {
+    let output = "tests/output_aarch64.png";
+    let options = default_options(output);
+
+    compute_mosaic(options);
+
+    let generated = load_image(output);
+    let ground = load_image("assets/ground-truth-kit.png");
+
+    assert_eq!(generated, ground);
+
+    std::fs::remove_file(output).unwrap();
+}
+
+#[test]
+fn test_generic() {
+    let output = "tests/output_generic.png";
+    let options = default_options(output);
+
+    compute_mosaic(options);
+
+    let generated = load_image(output);
+    let ground = load_image("assets/ground-truth-kit.png");
+
+    assert_eq!(generated, ground);
+
+    std::fs::remove_file(output).unwrap();
 }


### PR DESCRIPTION
Rajouter des tests unitaires pour tester le fonctionnement des fonctions l1_neon, l1_x86_sse2, l1_generic, prepare_target et prepare_tiles.