### PR TITLE
✅ add unit / integration test and refactor SIMD on main to avoid segfaults

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -465,6 +465,8 @@ mod tests {
                 assert_eq!(l1_x86_avx2(&im1, &im2), expected);
             } else if is_x86_feature_detected!("sse2") {
                 assert_eq!(l1_x86_sse2(&im1, &im2), expected);
+            } else {
+                panic!("No SIMD support detected on x86 platform - expected at least SSE2");
             }
         }
     }
@@ -519,11 +521,46 @@ mod tests {
 
     // === Prepare Functions Tests ===
 
+    /// RAII guard to ensure cleanup of test directories
+    struct DirCleanup {
+        path: String,
+    }
+
+    impl DirCleanup {
+        fn new(path: String) -> Self {
+            Self { path }
+        }
+    }
+
+    impl Drop for DirCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    /// RAII guard to ensure cleanup of test files
+    struct FileCleanup {
+        path: String,
+    }
+
+    impl FileCleanup {
+        fn new(path: String) -> Self {
+            Self { path }
+        }
+    }
+
+    impl Drop for FileCleanup {
+        fn drop(&mut self) {
+            let _ = fs::remove_file(&self.path);
+        }
+    }
+
     #[test]
     fn test_prepare_tiles_size() {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let id = COUNTER.fetch_add(1, Ordering::SeqCst);
         let dir = format!("test_tiles_{}", id);
+        let _cleanup = DirCleanup::new(dir.clone());
 
         fs::create_dir_all(&dir).unwrap();
         for i in 0..3 {
@@ -542,8 +579,6 @@ mod tests {
             assert_eq!(tile.width(), 4);
             assert_eq!(tile.height(), 4);
         }
-
-        fs::remove_dir_all(&dir).unwrap();
     }
 
     #[test]
@@ -551,6 +586,7 @@ mod tests {
         static COUNTER: AtomicUsize = AtomicUsize::new(0);
         let id = COUNTER.fetch_add(1, Ordering::SeqCst);
         let path = format!("test_input_{}.png", id);
+        let _cleanup = FileCleanup::new(path.clone());
 
         let img = RgbImage::new(8, 8);
         img.save(&path).unwrap();
@@ -563,7 +599,5 @@ mod tests {
 
         assert_eq!(result.width(), 8);
         assert_eq!(result.height(), 8);
-
-        fs::remove_file(&path).unwrap();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use image::{
-    imageops::{resize, FilterType::Nearest},
     GenericImage, GenericImageView, ImageReader, RgbImage,
+    imageops::{FilterType::Nearest, resize},
 };
 use std::time::Instant;
 use std::{
@@ -127,7 +127,6 @@ unsafe fn l1_x86_avx2(im1: &RgbImage, im2: &RgbImage) -> i32 {
     use std::arch::x86_64::{
         __m256i,
         _mm256_extract_epi16, //AVX2
-        _mm256_load_si256,    //AVX
         _mm256_loadu_si256,   //AVX
         _mm256_sad_epu8,      //AVX2
     };
@@ -151,7 +150,7 @@ unsafe fn l1_x86_avx2(im1: &RgbImage, im2: &RgbImage) -> i32 {
 
         // Load data to ymm
         let ymm_p1 = _mm256_loadu_si256(p_im1);
-        let ymm_p2 = _mm256_load_si256(p_im2);
+        let ymm_p2 = _mm256_loadu_si256(p_im2);
 
         // Do abs(a-b) and horizontal add, results are stored in lower 16 bits of each 64 bits groups
         let ymm_sub_abs = _mm256_sad_epu8(ymm_p1, ymm_p2);
@@ -184,7 +183,7 @@ unsafe fn l1_x86_sse2(im1: &RgbImage, im2: &RgbImage) -> i32 {
     use std::arch::x86_64::{
         __m128i,
         _mm_extract_epi16, //SSE2
-        _mm_load_si128,    //SSE2
+        _mm_loadu_si128,   //SSE2
         _mm_sad_epu8,      //SSE2
     };
 
@@ -206,8 +205,8 @@ unsafe fn l1_x86_sse2(im1: &RgbImage, im2: &RgbImage) -> i32 {
             std::mem::transmute::<*const u8, *const __m128i>(std::ptr::addr_of!(im2[i as usize]));
 
         // Load data to xmm
-        let xmm_p1 = _mm_load_si128(p_im1);
-        let xmm_p2 = _mm_load_si128(p_im2);
+        let xmm_p1 = _mm_loadu_si128(p_im1);
+        let xmm_p2 = _mm_loadu_si128(p_im2);
 
         // Do abs(a-b) and horizontal add, results are stored in lower 16 bits of each 64 bits groups
         let xmm_sub_abs = _mm_sad_epu8(xmm_p1, xmm_p2);
@@ -440,22 +439,131 @@ fn main() {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use image::RgbImage;
+    use std::fs;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    // Helper to create test images
+    fn create_test_images() -> (RgbImage, RgbImage, i32) {
+        let mut im1 = RgbImage::new(4, 4);
+        let mut im2 = RgbImage::new(4, 4);
+        im1.pixels_mut().for_each(|p| *p = image::Rgb([10, 20, 30]));
+        im2.pixels_mut().for_each(|p| *p = image::Rgb([15, 25, 35]));
+        let expected_distance = 4 * 4 * (5 + 5 + 5);
+        (im1, im2, expected_distance)
+    }
+
+    // === Basic L1 Distance Tests ===
+
     #[test]
     #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
     fn unit_test_x86() {
-        // TODO
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        unsafe {
+            if is_x86_feature_detected!("avx2") {
+                assert_eq!(l1_x86_avx2(&im1, &im2), expected);
+            } else if is_x86_feature_detected!("sse2") {
+                assert_eq!(l1_x86_sse2(&im1, &im2), expected);
+            }
+        }
     }
 
     #[test]
     #[cfg(target_arch = "aarch64")]
     fn unit_test_aarch64() {
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        unsafe {
+            assert_eq!(l1_neon(&im1, &im2), expected);
+        }
     }
 
     #[test]
     fn unit_test_generic() {
-        // TODO
-        assert!(true);
+        let (im1, im2, expected) = create_test_images();
+        assert_eq!(l1_generic(&im1, &im2), expected);
+    }
+
+    // === Edge Case Tests ===
+
+    #[test]
+    fn test_l1_generic_identical_images() {
+        let mut im1 = RgbImage::new(8, 8);
+        let mut im2 = RgbImage::new(8, 8);
+        im1.pixels_mut()
+            .for_each(|p| *p = image::Rgb([100, 150, 200]));
+        im2.pixels_mut()
+            .for_each(|p| *p = image::Rgb([100, 150, 200]));
+        assert_eq!(l1_generic(&im1, &im2), 0);
+    }
+
+    #[test]
+    fn test_l1_generic_minimal_image() {
+        let mut im1 = RgbImage::new(1, 1);
+        let mut im2 = RgbImage::new(1, 1);
+        im1.put_pixel(0, 0, image::Rgb([10, 20, 30]));
+        im2.put_pixel(0, 0, image::Rgb([15, 25, 35]));
+        assert_eq!(l1_generic(&im1, &im2), 15);
+    }
+
+    #[test]
+    fn test_l1_generic_max_difference() {
+        let mut im1 = RgbImage::new(2, 2);
+        let mut im2 = RgbImage::new(2, 2);
+        im1.pixels_mut().for_each(|p| *p = image::Rgb([0, 0, 0]));
+        im2.pixels_mut()
+            .for_each(|p| *p = image::Rgb([255, 255, 255]));
+        let expected = 2 * 2 * (255 + 255 + 255);
+        assert_eq!(l1_generic(&im1, &im2), expected);
+    }
+
+    // === Prepare Functions Tests ===
+
+    #[test]
+    fn test_prepare_tiles_size() {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let dir = format!("test_tiles_{}", id);
+
+        fs::create_dir_all(&dir).unwrap();
+        for i in 0..3 {
+            let img = RgbImage::new(8, 8);
+            img.save(format!("{}/img{}.png", dir, i)).unwrap();
+        }
+
+        let tile_size = Size {
+            width: 4,
+            height: 4,
+        };
+        let tiles = prepare_tiles(&dir, &tile_size, false).unwrap();
+
+        assert_eq!(tiles.len(), 3);
+        for tile in tiles {
+            assert_eq!(tile.width(), 4);
+            assert_eq!(tile.height(), 4);
+        }
+
+        fs::remove_dir_all(&dir).unwrap();
+    }
+
+    #[test]
+    fn test_prepare_target_size() {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let id = COUNTER.fetch_add(1, Ordering::SeqCst);
+        let path = format!("test_input_{}.png", id);
+
+        let img = RgbImage::new(8, 8);
+        img.save(&path).unwrap();
+
+        let tile_size = Size {
+            width: 4,
+            height: 4,
+        };
+        let result = prepare_target(&path, 1, &tile_size).unwrap();
+
+        assert_eq!(result.width(), 8);
+        assert_eq!(result.height(), 8);
+
+        fs::remove_file(&path).unwrap();
     }
 }

--- a/tests/temp.rs
+++ b/tests/temp.rs
@@ -1,6 +1,23 @@
 use moseiik::main::compute_mosaic;
-use std::fs;
-use std::path::Path;
+
+/// RAII guard to ensure cleanup of test output files
+struct TestCleanup {
+    path: String,
+}
+
+impl TestCleanup {
+    fn new(path: &str) -> Self {
+        Self {
+            path: path.to_string(),
+        }
+    }
+}
+
+impl Drop for TestCleanup {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
 
 /// Integration test for x86/x86_64 SIMD implementation
 /// Uses large image to test complete pipeline with SSE2/AVX2
@@ -9,9 +26,8 @@ use std::path::Path;
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 fn test_x86() {
     let output = "test_output_x86.png";
+    let _cleanup = TestCleanup::new(output);
     run_integration_test(true, output);
-    assert!(Path::new(output).exists(), "Output file should exist");
-    cleanup(output);
 }
 
 /// Integration test for ARM NEON SIMD implementation
@@ -21,9 +37,8 @@ fn test_x86() {
 #[cfg(target_arch = "aarch64")]
 fn test_aarch64() {
     let output = "test_output_aarch64.png";
+    let _cleanup = TestCleanup::new(output);
     run_integration_test(true, output);
-    assert!(Path::new(output).exists(), "Output file should exist");
-    cleanup(output);
 }
 
 /// Integration test for generic (non-SIMD) implementation
@@ -32,9 +47,8 @@ fn test_aarch64() {
 #[ignore] // Slow test - run with: cargo test -- --ignored
 fn test_generic() {
     let output = "test_output_generic.png";
+    let _cleanup = TestCleanup::new(output);
     run_integration_test(false, output);
-    assert!(Path::new(output).exists(), "Output file should exist");
-    cleanup(output);
 }
 
 /// Helper function for integration tests
@@ -56,13 +70,18 @@ fn run_integration_test(use_simd: bool, output_path: &str) {
     compute_mosaic(args);
 
     // Verify output exists and dimensions are reasonable
+    // Note: These dimensions are specific to assets/kit.jpeg (1920x1080)
+    // with 25x25 tiles. The mosaic algorithm may adjust final dimensions
+    // to multiples of tile size (1920/25=76.8 -> 76 tiles * 25 = 1900px width).
     let output_img = image::open(output_path).expect("Failed to open output");
-    // Mosaic tiles may adjust final dimensions slightly
-    assert!(output_img.width() >= 1900 && output_img.width() <= 1920);
-    assert!(output_img.height() >= 1050 && output_img.height() <= 1080);
-}
-
-/// Cleanup helper
-fn cleanup(path: &str) {
-    let _ = fs::remove_file(path);
+    assert!(
+        output_img.width() >= 1900 && output_img.width() <= 1920,
+        "Output width {} is outside expected range [1900-1920]",
+        output_img.width()
+    );
+    assert!(
+        output_img.height() >= 1050 && output_img.height() <= 1080,
+        "Output height {} is outside expected range [1050-1080]",
+        output_img.height()
+    );
 }

--- a/tests/temp.rs
+++ b/tests/temp.rs
@@ -1,23 +1,68 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
-    fn test_x86() {
-        // TODO
-        // test avx2 or sse2 if available
-        assert!(false);
-    }
+use moseiik::main::compute_mosaic;
+use std::fs;
+use std::path::Path;
 
-    #[test]
-    #[cfg(target_arch = "aarch64")]
-    fn test_aarch64() {
-        //TODO
-        assert!(false);
-    }
+/// Integration test for x86/x86_64 SIMD implementation
+/// Uses large image to test complete pipeline with SSE2/AVX2
+#[test]
+#[ignore] // Slow test - run with: cargo test -- --ignored
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+fn test_x86() {
+    let output = "test_output_x86.png";
+    run_integration_test(true, output);
+    assert!(Path::new(output).exists(), "Output file should exist");
+    cleanup(output);
+}
 
-    #[test]
-    fn test_generic() {
-        //TODO
-        assert!(false);
-    }
+/// Integration test for ARM NEON SIMD implementation
+/// Uses large image to test complete pipeline with NEON
+#[test]
+#[ignore] // Slow test - run with: cargo test -- --ignored
+#[cfg(target_arch = "aarch64")]
+fn test_aarch64() {
+    let output = "test_output_aarch64.png";
+    run_integration_test(true, output);
+    assert!(Path::new(output).exists(), "Output file should exist");
+    cleanup(output);
+}
+
+/// Integration test for generic (non-SIMD) implementation
+/// Uses large image to test complete pipeline without SIMD
+#[test]
+#[ignore] // Slow test - run with: cargo test -- --ignored
+fn test_generic() {
+    let output = "test_output_generic.png";
+    run_integration_test(false, output);
+    assert!(Path::new(output).exists(), "Output file should exist");
+    cleanup(output);
+}
+
+/// Helper function for integration tests
+fn run_integration_test(use_simd: bool, output_path: &str) {
+    use moseiik::main::Options;
+
+    let args = Options {
+        image: "assets/kit.jpeg".to_string(),
+        tiles: "assets/images".to_string(),
+        tile_size: 25,
+        output: output_path.to_string(),
+        verbose: false,
+        scaling: 1,
+        num_thread: 4,
+        simd: use_simd,
+        remove_used: false,
+    };
+
+    compute_mosaic(args);
+
+    // Verify output exists and dimensions are reasonable
+    let output_img = image::open(output_path).expect("Failed to open output");
+    // Mosaic tiles may adjust final dimensions slightly
+    assert!(output_img.width() >= 1900 && output_img.width() <= 1920);
+    assert!(output_img.height() >= 1050 && output_img.height() <= 1080);
+}
+
+/// Cleanup helper
+fn cleanup(path: &str) {
+    let _ = fs::remove_file(path);
 }


### PR DESCRIPTION
This pull request adds comprehensive unit and integration tests for the image mosaic project, improves SIMD compatibility, and fixes minor import issues. The most important changes are grouped below:

**Testing Improvements**

* Added extensive unit tests to `src/main.rs` for L1 distance functions, edge cases, and tile/target preparation, ensuring correctness for all supported architectures and scenarios.
* Replaced placeholder integration tests in `tests/temp.rs` with full pipeline tests for x86, ARM NEON, and generic implementations, including output file verification and cleanup helpers.

**SIMD Compatibility and Correctness**

* Updated AVX2 and SSE2 implementations in `src/main.rs` to use unaligned memory loads (`_mm256_loadu_si256` and `_mm_loadu_si128`) for better compatibility and correctness, replacing the previous aligned loads. [[1]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL154-R153) [[2]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL209-R209) [[3]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL187-R186) [[4]](diffhunk://#diff-42cb6807ad74b3e201c5a7ca98b911c5fa08380e942be6e4ac5807f8377f87fcL130)

**Code Quality**

* Minor import reordering in `src/main.rs` for consistency and clarity.